### PR TITLE
Fix example groovy code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ import hudson.security.AuthorizationStrategy
 import hudson.security.SecurityRealm
 import jenkins.model.Jenkins
 import org.jenkinsci.plugins.BitbucketSecurityRealm
+import hudson.util.Secret
 
 // parameters
 def bitbucketSecurityRealmParameters = [
@@ -69,7 +70,8 @@ def bitbucketSecurityRealmParameters = [
 // security realm configuration
 SecurityRealm bitbucketSecurityRealm = new BitbucketSecurityRealm(
   bitbucketSecurityRealmParameters.clientID,
-  bitbucketSecurityRealmParameters.clientSecret
+  "",
+  Secret.fromString(bitbucketSecurityRealmParameters.clientSecret)
 )
 
 // authorization strategy - full control when logged in


### PR DESCRIPTION
hey folks,

the example code was broken in README.md because the underlying class had introduced changes in the class constructor:
- it requires 3 parameters instead of 2
- and it also does not use the non-encrypted version of the oauth secret, so i just passed and empty string there

hope to see this simple PR merged soon as it could help others who are trying to set up this plugin.