### PR TITLE
Fix API token authentication failing with UserMayOrMayNotExistException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
@@ -40,10 +40,11 @@ import hudson.model.Descriptor;
 import hudson.model.User;
 import hudson.security.GroupDetails;
 import hudson.security.SecurityRealm;
-import hudson.security.UserMayOrMayNotExistException;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
+import jenkins.security.LastGrantedAuthoritiesProperty;
 import jenkins.security.SecurityListener;
+import org.springframework.security.core.GrantedAuthority;
 import java.util.Collection;
 
 public class BitbucketSecurityRealm extends SecurityRealm {
@@ -180,6 +181,7 @@ public class BitbucketSecurityRealm extends SecurityRealm {
             BitbucketUser userDetails = auth.getBitbucketUser();
             if (userDetails != null) {
                 SecurityListener.fireAuthenticated2(userDetails);
+                SecurityListener.fireLoggedIn(userDetails.getUsername());
             }
         } else {
             LOGGER.log(Level.SEVERE, "doFinishLogin() accessToken = null");
@@ -203,29 +205,34 @@ public class BitbucketSecurityRealm extends SecurityRealm {
 
                 throw new BadCredentialsException("Unexpected authentication type: " + authentication);
             }
-        }, new UserDetailsService() {
-            public UserDetails loadUserByUsername(String username)
-                    throws UserMayOrMayNotExistException, DataAccessException {
-                throw new UserMayOrMayNotExistException("Cannot verify users in this context");
-            }
-        });
+        }, username -> loadUserByUsername2(username));
     }
 
     @Override
     public UserDetails loadUserByUsername2(String username) {
-        UserDetails result = null;
         Authentication token = SecurityContextHolder.getContext().getAuthentication();
-        if (token == null) {
-            throw new UsernameNotFoundException("BitbucketAuthenticationToken = null, no known user: " + username);
-        }
-        if (!(token instanceof BitbucketAuthenticationToken)) {
-            throw new UserMayOrMayNotExistException("Unexpected authentication type: " + token);
-        }
-        result = new BitbucketApiService(clientID, getSecretClientSecret().getPlainText()).getUserByUsername(username);
-        if (result == null) {
+        if (token instanceof BitbucketAuthenticationToken) {
+            BitbucketUser user = ((BitbucketAuthenticationToken) token).getBitbucketUser();
+            if (user != null && username.equals(user.getUsername())) {
+                return user;
+            }
             throw new UsernameNotFoundException("User does not exist for login: " + username);
         }
-        return result;
+        // For API token authentication: restore authorities from the last OAuth login.
+        BitbucketUser user = new BitbucketUser();
+        user.username = username;
+        User jenkinsUser = User.getById(username, false);
+        if (jenkinsUser != null) {
+            LastGrantedAuthoritiesProperty prop = jenkinsUser.getProperty(LastGrantedAuthoritiesProperty.class);
+            if (prop != null) {
+                for (GrantedAuthority authority : prop.getAuthorities2()) {
+                    user.addAuthority(authority.getAuthority());
+                }
+                return user;
+            }
+        }
+        user.addAuthority("authenticated");
+        return user;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.StringUtils;
@@ -25,7 +24,6 @@ import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
 import org.kohsuke.stapler.StaplerRequest2;
 import org.scribe.model.Token;
-import org.springframework.dao.DataAccessException;
 
 import com.thoughtworks.xstream.converters.ConversionException;
 import com.thoughtworks.xstream.converters.Converter;
@@ -45,7 +43,6 @@ import jenkins.model.Jenkins;
 import jenkins.security.LastGrantedAuthoritiesProperty;
 import jenkins.security.SecurityListener;
 import org.springframework.security.core.GrantedAuthority;
-import java.util.Collection;
 
 public class BitbucketSecurityRealm extends SecurityRealm {
 

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
@@ -1,15 +1,8 @@
 package org.jenkinsci.plugins.api;
 
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.logging.Logger;
 
-import org.springframework.security.core.userdetails.UserDetails;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.model.OAuthRequest;
@@ -20,7 +13,6 @@ import org.scribe.model.Verifier;
 import org.scribe.oauth.OAuthService;
 
 import com.google.gson.Gson;
-import java.util.Collection;
 
 public class BitbucketApiService {
 
@@ -43,11 +35,7 @@ public class BitbucketApiService {
         service = builder.build();
     }
 
-    public Token createRquestToken() {
-        return service.getRequestToken();
-    }
-
-    public String createAuthorizationCodeURL(Token requestToken, String state) {
+public String createAuthorizationCodeURL(Token requestToken, String state) {
         return service.getAuthorizationUrl(requestToken) + "&state=" + state;
     }
 
@@ -124,31 +112,6 @@ public class BitbucketApiService {
         } catch (Exception e) {
             // Some error, So ignore it and move on.
             e.printStackTrace();
-        }
-    }
-
-    public UserDetails getUserByUsername(String username) {
-        InputStreamReader reader = null;
-        UserDetails userResponce = null;
-        try {
-            URL url = new URL(API2_ENDPOINT + "users/" + username);
-            reader = new InputStreamReader(url.openStream(), "UTF-8");
-            Gson gson = new Gson();
-            userResponce = gson.fromJson(reader, BitbucketUser.class);
-        } catch (UnsupportedEncodingException e) {
-            e.printStackTrace();
-        } catch (MalformedURLException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(reader);
-        }
-
-        if (userResponce != null) {
-            return userResponce;
-        } else {
-            return null;
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug where Jenkins API token authentication always failed with `UserMayOrMayNotExistException` when using the Bitbucket OAuth plugin as the security realm.

## Problem

Two issues were causing API token authentication (HTTP Basic Auth with `username:api-token`) to fail:

1. **`UserDetailsService` always threw an exception**: The `UserDetailsService` returned by `createSecurityComponents()` unconditionally threw `UserMayOrMayNotExistException`, blocking Jenkins from loading user details during API token authentication.

2. **`LastGrantedAuthoritiesProperty` was never populated**: `doFinishLogin()` only called `SecurityListener.fireAuthenticated2()` after a successful OAuth login, but `LastGrantedAuthoritiesProperty$SecurityListenerImpl` listens to `fireLoggedIn()` — not `fireAuthenticated2()`. As a result, workspace authorities (e.g. `myworkspace::member`) were never persisted, and could not be restored during subsequent API token requests.

## Key Changes

- **`createSecurityComponents()`**: The `UserDetailsService` now delegates to `loadUserByUsername2()` instead of unconditionally throwing.
- **`loadUserByUsername2()`**: Handles two distinct contexts:
  - **OAuth browser login**: When `BitbucketAuthenticationToken` is present in the security context, returns the user directly from the token (workspace authorities
  included).
  - **API token authentication**: Restores the user's workspace authorities from `LastGrantedAuthoritiesProperty`, which is populated at OAuth login time. Falls back to `authenticated` authority only if no property has been saved yet (e.g. first-ever login).
- **`doFinishLogin()`**: Added `SecurityListener.fireLoggedIn()` call after a successful OAuth login to ensure `LastGrantedAuthoritiesProperty` is populated for future API token requests.

## Verification

- Confirmed the original `UserMayOrMayNotExistException` stack trace is reproducible without this patch.
- Verified that after an OAuth browser login, subsequent API token requests (`curl -u username:token`) succeed with the correct workspace authorities.
- Compiled and tested successfully with `mvn package`.