### PR TITLE
OAuth authentication broken during Bitbucket brownout windows (May 2026 deprecation) 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Version History
 
+### Version 0.17 (28 Apr, 2026)
+
+* Fix OAuth 2.0 access token passed as query parameter, causing HTTP 401 failures during Bitbucket brownout windows (enforcement date: 4 May 2026) (related: [PR #16](https://github.com/jenkinsci/bitbucket-oauth-plugin/pull/16))
+
 ### Version 0.16 (19 Apr, 2026)
 
 * Fix API token authentication failing with UserMayOrMayNotExistException (related: [PR #15](https://github.com/jenkinsci/bitbucket-oauth-plugin/pull/15))

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
 			<artifactId>scribe</artifactId>
 			<version>1.3.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock-standalone</artifactId>
+			<version>3.9.1</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
@@ -66,7 +66,7 @@ public class BitbucketApiService {
     private BitbucketUser getBitbucketUserV2(Token accessToken) {
         // require "Account Read" permission
         OAuthRequest request = new OAuthRequest(Verb.GET, API2_ENDPOINT + "user");
-        service.signRequest(accessToken, request);
+        request.addHeader("Authorization", "Bearer " + accessToken.getToken());
         Response response = request.send();
         String json = response.getBody();
         Gson gson = new Gson();
@@ -83,7 +83,7 @@ public class BitbucketApiService {
         try {
             do {
                 OAuthRequest request1 = new OAuthRequest(Verb.GET, url);
-                service.signRequest(accessToken, request1);
+                request1.addHeader("Authorization", "Bearer " + accessToken.getToken());
                 Response response1 = request1.send();
                 String json1 = response1.getBody();
 

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
@@ -18,7 +18,12 @@ public class BitbucketApiService {
 
     private static final Logger LOGGER = Logger.getLogger(BitbucketApiService.class.getName());
 
-    private static final String API2_ENDPOINT = "https://api.bitbucket.org/2.0/";
+    private String apiEndpoint = "https://api.bitbucket.org/2.0/";
+
+    // package-private for testing
+    void setApiEndpoint(String apiEndpoint) {
+        this.apiEndpoint = apiEndpoint;
+    }
 
     private OAuthService service;
 
@@ -65,7 +70,7 @@ public class BitbucketApiService {
 
     private BitbucketUser getBitbucketUserV2(Token accessToken) {
         // require "Account Read" permission
-        OAuthRequest request = new OAuthRequest(Verb.GET, API2_ENDPOINT + "user");
+        OAuthRequest request = new OAuthRequest(Verb.GET, apiEndpoint + "user");
         request.addHeader("Authorization", "Bearer " + accessToken.getToken());
         Response response = request.send();
         String json = response.getBody();
@@ -79,7 +84,7 @@ public class BitbucketApiService {
 
     private void findAndAddUserWorkspaceAccess(Token accessToken, BitbucketUser bitbucketUser) {
         Gson gson = new Gson();
-        String url = API2_ENDPOINT + "user/workspaces";
+        String url = apiEndpoint + "user/workspaces";
         try {
             do {
                 OAuthRequest request1 = new OAuthRequest(Verb.GET, url);

--- a/src/test/java/org/jenkinsci/plugins/api/BitbucketApiServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/api/BitbucketApiServiceTest.java
@@ -1,0 +1,80 @@
+package org.jenkinsci.plugins.api;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.scribe.model.Token;
+
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BitbucketApiServiceTest {
+
+    private WireMockServer wireMock;
+    private BitbucketApiService service;
+
+    @BeforeEach
+    void setUp() {
+        wireMock = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+        wireMock.start();
+
+        wireMock.stubFor(get(urlPathEqualTo("/2.0/user"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"username\":\"testuser\",\"display_name\":\"Test User\"}")));
+
+        wireMock.stubFor(get(urlPathEqualTo("/2.0/user/workspaces"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"values\":[]}")));
+
+        service = new BitbucketApiService("clientId", "clientSecret");
+        service.setApiEndpoint("http://localhost:" + wireMock.port() + "/2.0/");
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMock.stop();
+    }
+
+    @Test
+    void userRequest_usesBearerAuthorizationHeader() {
+        service.getUserByToken(new Token("test-access-token", ""));
+
+        List<LoggedRequest> requests = wireMock.findAll(getRequestedFor(urlPathEqualTo("/2.0/user")));
+        assertEquals(1, requests.size());
+        assertEquals("Bearer test-access-token", requests.get(0).getHeader("Authorization"));
+    }
+
+    @Test
+    void userRequest_doesNotPassTokenAsQueryParameter() {
+        service.getUserByToken(new Token("test-access-token", ""));
+
+        List<LoggedRequest> requests = wireMock.findAll(getRequestedFor(urlPathEqualTo("/2.0/user")));
+        assertEquals(1, requests.size());
+        assertFalse(requests.get(0).queryParameter("access_token").isPresent());
+    }
+
+    @Test
+    void workspacesRequest_usesBearerAuthorizationHeader() {
+        service.getUserByToken(new Token("test-access-token", ""));
+
+        List<LoggedRequest> requests = wireMock.findAll(getRequestedFor(urlPathEqualTo("/2.0/user/workspaces")));
+        assertEquals(1, requests.size());
+        assertEquals("Bearer test-access-token", requests.get(0).getHeader("Authorization"));
+    }
+
+    @Test
+    void workspacesRequest_doesNotPassTokenAsQueryParameter() {
+        service.getUserByToken(new Token("test-access-token", ""));
+
+        List<LoggedRequest> requests = wireMock.findAll(getRequestedFor(urlPathEqualTo("/2.0/user/workspaces")));
+        assertEquals(1, requests.size());
+        assertFalse(requests.get(0).queryParameter("access_token").isPresent());
+    }
+}


### PR DESCRIPTION
# Summary

Jenkins login via Bitbucket OAuth fails intermittently with HTTP 401 errors during Bitbucket's brownout 
windows (April 20 – May 4 2026), and will fail permanently after May 4 2026.
                                                                                              
## Root Cause                                                

Bitbucket is deprecating OAuth access tokens passed as query parameters or POST body fields. The Scribe 
1.3.x library used by this plugin implements `OAuth20ServiceImpl.signRequest()` by appending the token as
an `access_token` query string parameter on every API call. Bitbucket now rejects these requests with HTTP
401 during brownout windows.                             

## Affected calls:                                                                                         
- GET https://api.bitbucket.org/2.0/user
- GET https://api.bitbucket.org/2.0/user/workspaces                                                     
                                                
## Expected Behaviour

API calls should authenticate using the `Authorization: Bearer <token>` header, which is the correct OAuth
2.0 approach and is not affected by the deprecation.
                                                                                              
## Steps to Reproduce                                        

1. Configure Jenkins with this plugin for Bitbucket OAuth authentication
2. Attempt to log in during a Bitbucket brownout window
3. Login fails with HTTP 401                                                                            

## Fix                                                                                                     
                                                
Replace `service.signRequest(accessToken, request)` with `request.addHeader("Authorization", "Bearer " +   
accessToken.getToken())` in `BitbucketApiService.java`.
                                                                                              
## References                                                

- [Bitbucket Cloud changelog — OAuth 2.0 and API authentication changes       ](https://developer.atlassian.com/cloud/bitbucket/changelog/)