### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
@@ -2,7 +2,6 @@ package org.jenkinsci.plugins;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.api.BitbucketApiService;
 import org.jenkinsci.plugins.api.BitbucketUser;
 import org.kohsuke.accmod.Restricted;
@@ -46,7 +45,7 @@ public class BitbucketAuthenticationToken extends AbstractAuthenticationToken {
 
     @Override
     public Object getCredentials() {
-        return StringUtils.EMPTY;
+        return "";
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
@@ -1,11 +1,10 @@
 package org.jenkinsci.plugins;
 
 import java.io.IOException;
+import java.security.SecureRandom;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.api.BitbucketApiService;
 import org.jenkinsci.plugins.api.BitbucketGroup;
 import org.jenkinsci.plugins.api.BitbucketUser;
@@ -47,6 +46,9 @@ import jenkins.security.SecurityListener;
 public class BitbucketSecurityRealm extends SecurityRealm {
 
     private static final String STATE_ATTRIBUTE = BitbucketSecurityRealm.class.getName() + ".state";
+    private static final String STATE_CHARACTERS =
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~";
+    private static final SecureRandom STATE_RANDOM = new SecureRandom();
     private static final String REFERER_ATTRIBUTE = BitbucketSecurityRealm.class.getName() + ".referer";
     private static final Logger LOGGER = Logger.getLogger(BitbucketSecurityRealm.class.getName());
 
@@ -103,7 +105,7 @@ public class BitbucketSecurityRealm extends SecurityRealm {
      */
     public Secret getSecretClientSecret() {
         // for backward compatibility
-        if (StringUtils.isNotEmpty(clientSecret)) {
+        if (Util.fixEmpty(clientSecret) != null) {
             return Secret.fromString(clientSecret);
         }
         return secretClientSecret;
@@ -119,7 +121,7 @@ public class BitbucketSecurityRealm extends SecurityRealm {
     public HttpResponse doCommenceLogin(StaplerRequest2 request, @Header("Referer") final String referer)
             throws IOException {
 
-        String state = RandomStringUtils.random(64, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~");
+        String state = randomState();
         request.getSession().setAttribute(STATE_ATTRIBUTE, state);
         request.getSession().setAttribute(REFERER_ATTRIBUTE, referer);
 
@@ -128,8 +130,8 @@ public class BitbucketSecurityRealm extends SecurityRealm {
             throw new RuntimeException("Jenkins is not started yet.");
         }
         String rootUrl = jenkins.getRootUrl();
-        if (StringUtils.endsWith(rootUrl, "/")) {
-            rootUrl = StringUtils.left(rootUrl, StringUtils.length(rootUrl) - 1);
+        if (rootUrl != null && rootUrl.endsWith("/")) {
+            rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
         }
         String callback = rootUrl + "/securityRealm/finishLogin";
 
@@ -142,12 +144,12 @@ public class BitbucketSecurityRealm extends SecurityRealm {
         String code = request.getParameter("code");
         String state = request.getParameter("state");
 
-        if (StringUtils.isBlank(code)) {
+        if (Util.fixEmptyAndTrim(code) == null) {
             LOGGER.log(Level.SEVERE, "doFinishLogin() code = null");
             return HttpResponses.redirectToContextRoot();
         }
 
-        if (state == null || !StringUtils.equals(state, getSessionAttribute(request, STATE_ATTRIBUTE))) {
+        if (state == null || !state.equals(getSessionAttribute(request, STATE_ATTRIBUTE))) {
             LOGGER.log(Level.SEVERE, "doFinishLogin() invalid state parameter");
             return HttpResponses.redirectToContextRoot();
         }
@@ -253,6 +255,14 @@ public class BitbucketSecurityRealm extends SecurityRealm {
     @Override
     public String getLoginUrl() {
         return "securityRealm/commenceLogin";
+    }
+
+    private static String randomState() {
+        StringBuilder state = new StringBuilder(64);
+        for (int i = 0; i < 64; i++) {
+            state.append(STATE_CHARACTERS.charAt(STATE_RANDOM.nextInt(STATE_CHARACTERS.length())));
+        }
+        return state.toString();
     }
 
     private String getSessionAttribute(StaplerRequest2 request, String attributeName) {

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketApiService.java
@@ -3,7 +3,7 @@ package org.jenkinsci.plugins.api;
 import java.util.logging.Logger;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
+import hudson.Util;
 import org.scribe.builder.ServiceBuilder;
 import org.scribe.model.OAuthRequest;
 import org.scribe.model.Response;
@@ -34,7 +34,7 @@ public class BitbucketApiService {
     public BitbucketApiService(String apiKey, String apiSecret, String callback) {
         super();
         ServiceBuilder builder = new ServiceBuilder().provider(BitbucketApiV2.class).apiKey(apiKey).apiSecret(apiSecret);
-        if (StringUtils.isNotBlank(callback)) {
+        if (Util.fixEmptyAndTrim(callback) != null) {
             builder.callback(callback);
         }
         service = builder.build();
@@ -76,7 +76,7 @@ public class BitbucketApiService {
         String json = response.getBody();
         Gson gson = new Gson();
         BitbucketUser bitbucketUser = gson.fromJson(json, BitbucketUser.class);
-        if (bitbucketUser == null || StringUtils.isEmpty(bitbucketUser.username)) {
+        if (bitbucketUser == null || Util.fixEmpty(bitbucketUser.username) == null) {
             return null;
         }
         return bitbucketUser;

--- a/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
+++ b/src/main/java/org/jenkinsci/plugins/api/BitbucketUser.java
@@ -4,14 +4,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 public class BitbucketUser implements UserDetails {
 
-    public String username = StringUtils.EMPTY;
+    public String username = "";
 
     List<GrantedAuthority> grantedAuthorties = new ArrayList<GrantedAuthority>();
 


### PR DESCRIPTION
No need to use a third-party library when this functionality is available in the Java Platform.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

## What's changed
- `StringUtils.EMPTY` → `""`; `isEmpty`/`isNotEmpty`/`isBlank` → the `hudson.Util.fixEmpty*` helpers
  (`hudson.Util` was already imported here).
- `StringUtils.endsWith` + `left`/`length` → plain `endsWith` and `substring`.
- `StringUtils.equals(state, ...)` → `state.equals(...)`; `state` is null-checked immediately before.

### Please review this part specifically

The OAuth `state` parameter was generated with
`RandomStringUtils.random(64, "abc...XYZ0123456789-._~")`. Commons Lang 2's `RandomStringUtils` is backed
by a plain `java.util.Random`, which is **not** cryptographically secure — and `state` is the CSRF
protection for the login flow.

Rather than hand-write a non-secure generator for a security token, I replaced it with a `SecureRandom`
drawing from the same character set, so the token is the same length and alphabet as before. This is a
deliberate behaviour change beyond a pure library swap, and it is separable — say the word and I will
drop it back to `java.util.Random` and leave the hardening for a separate PR.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.7` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
