### PR TITLE
Use gson-api plugin instead of direct gson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,10 +46,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.9</version>
-			<scope>compile</scope>
+			<groupId>io.jenkins.plugins</groupId>
+			<artifactId>gson-api</artifactId>
+			<version>2.14.0-201.v8eefe5515533</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scribe</groupId>


### PR DESCRIPTION
Rely on the Jenkins-provided GSON API plugin (io.jenkins.plugins:gson-api) so the gson version is managed centrally via the update center/BOM instead of bundling it directly in this plugin.

Use the `UseGsonApiPlugin` recipe of [plugin-modernizer-tool](https://github.com/jenkins-infra/plugin-modernizer-tool)