### PR TITLE
Add Jenkins plugins BOM and migrate to jenkins.baseline property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,17 @@
 			<comments>All source code is under the MIT license.</comments>
 		</license>
 	</licenses>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>io.jenkins.tools.bom</groupId>
+				<artifactId>bom-${jenkins.baseline}.x</artifactId>
+				<version>6815.v1fb_2a_fee3765</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<repositories>
 		<repository>
@@ -48,7 +59,6 @@
 		<dependency>
 			<groupId>io.jenkins.plugins</groupId>
 			<artifactId>gson-api</artifactId>
-			<version>2.14.0-201.v8eefe5515533</version>
 		</dependency>
 		<dependency>
 			<groupId>org.scribe</groupId>
@@ -79,7 +89,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<jenkins.version>2.541.3</jenkins.version>
+		<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+		<jenkins.baseline>2.541</jenkins.baseline>
+		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
 		<ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
 	</properties>
 </project>


### PR DESCRIPTION
Import io.jenkins.tools.bom:bom-2.541.x via dependencyManagement so plugin dependency versions (e.g. gson-api) are managed centrally. Introduce the jenkins.baseline property and derive jenkins.version from it, per the Jenkins baseline convention.

Use the `AddPluginsBom` recipe of [plugin-modernizer-tool](https://github.com/jenkins-infra/plugin-modernizer-tool).