### PR TITLE
Enable ban-junit4-imports check and make test class package-private

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,5 +93,6 @@
 		<jenkins.baseline>2.541</jenkins.baseline>
 		<jenkins.version>${jenkins.baseline}.3</jenkins.version>
 		<ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
+		<ban-junit4-imports.skip>false</ban-junit4-imports.skip>
 	</properties>
 </project>

--- a/src/test/java/org/jenkinsci/plugins/api/BitbucketApiServiceTest.java
+++ b/src/test/java/org/jenkinsci/plugins/api/BitbucketApiServiceTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class BitbucketApiServiceTest {
+class BitbucketApiServiceTest {
 
     private WireMockServer wireMock;
     private BitbucketApiService service;


### PR DESCRIPTION
Set ban-junit4-imports.skip to false now that all tests use JUnit 5, so future JUnit 4 imports are caught automatically. Also drop the redundant public modifier on BitbucketApiServiceTest per JUnit 5 convention.

Use the `MigrateToJUnit5` recipe of [plugin-modernizer-tool](https://github.com/jenkins-infra/plugin-modernizer-tool).