### PR TITLE
Migrate plugins to Java 25 LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ buildPlugin(
     forkCount: '1C', // Run a JVM per core in tests
     useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
     configurations: [
-        [platform: 'linux', jdk: 21],
-        [platform: 'windows', jdk: 17]
+        [platform: 'linux', jdk: 25],
+        [platform: 'windows', jdk: 21]
     ]
 )

--- a/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketAuthenticationToken.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.List;
 
@@ -13,6 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
 
 public class BitbucketAuthenticationToken extends AbstractAuthenticationToken {
 
+    @Serial
     private static final long serialVersionUID = -7826610577724673531L;
 
     private Token accessToken;

--- a/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/BitbucketSecurityRealm.java
@@ -214,8 +214,8 @@ public class BitbucketSecurityRealm extends SecurityRealm {
     @Override
     public UserDetails loadUserByUsername2(String username) {
         Authentication token = SecurityContextHolder.getContext().getAuthentication();
-        if (token instanceof BitbucketAuthenticationToken) {
-            BitbucketUser user = ((BitbucketAuthenticationToken) token).getBitbucketUser();
+        if (token instanceof BitbucketAuthenticationToken authenticationToken) {
+            BitbucketUser user = authenticationToken.getBitbucketUser();
             if (user != null && username.equals(user.getUsername())) {
                 return user;
             }


### PR DESCRIPTION
Apply Java 17/21/25 language modernizations: use pattern matching for instanceof in BitbucketSecurityRealm and add @Serial to the serialVersionUID field in BitbucketAuthenticationToken. Bump CI to build against JDK 25 (Linux) and JDK 21 (Windows); both are already supported by Jenkins core on the current 2.541.x baseline.

Use the `MigrateToJava25` recipe of [plugin-modernizer-tool](https://github.com/jenkins-infra/plugin-modernizer-tool)