### PR TITLE
Add auto-merge workflows for safe dependency updates

### DIFF
--- a/.github/workflows/auto-merge-safe-deps.yml
+++ b/.github/workflows/auto-merge-safe-deps.yml
@@ -1,0 +1,9 @@
+name: Automatically approve and merge safe dependency updates
+on:
+  - pull_request_target
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge-safe-deps:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/auto-merge-safe-deps.yml@v1

--- a/.github/workflows/close-bom-if-passing.yml
+++ b/.github/workflows/close-bom-if-passing.yml
@@ -1,0 +1,11 @@
+name: Close BOM update PR if passing
+on:
+  check_run:
+    types:
+      - completed
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  close-bom-if-passing:
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/close-bom-if-passing.yml@v1


### PR DESCRIPTION
Automatically approve and merge Dependabot/Renovate PRs that bump the org.jenkins-ci.plugins:plugin parent or the
git-changelist-maven-extension, since these are vetted Jenkins ecosystem releases. Also close BOM update PRs once their CI check passes, since BOM patch bumps don't need to be committed.

Use the `AutoMergeWorkflows` recipe of [plugin-modernizer-tool](https://github.com/jenkins-infra/plugin-modernizer-tool).